### PR TITLE
fix: use appropriate grant type for resource owner and client credent…

### DIFF
--- a/auth-betta/resources/client.md
+++ b/auth-betta/resources/client.md
@@ -34,7 +34,7 @@ grant_types: ['basic']
 {% code title="client-credentials" %}
 ```yaml
 resourceType: Client
-grant_types: ['basic']
+grant_types: ['client_credentials']
 
 ```
 {% endcode %}
@@ -45,7 +45,7 @@ grant_types: ['basic']
 ```yaml
 resourceType: Client
 id: password-client
-grant_types: ['basic']
+grant_types: ['password']
 
 ```
 {% endcode %}


### PR DESCRIPTION
…ials authorisations

grant_type = "password" for Resource Owner Password Credentials Grant
grant_type = "client_credentials" for Client Credentials Grant

https://tools.ietf.org/html/rfc6749